### PR TITLE
export pm conversion methods

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,4 @@ export {
   type BlockMappingSpec,
 } from "./schema"
 export { basicSchemaAdapter } from "./basicSchema"
-export { default as amToPm } from "./amToPm"
-export { default as pmToAm } from "./pmToAm"
-
+export { docFromSpans, blocksFromNode } from "./traversal"

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,3 +8,6 @@ export {
   type BlockMappingSpec,
 } from "./schema"
 export { basicSchemaAdapter } from "./basicSchema"
+export { default as amToPm } from "./amToPm"
+export { default as pmToAm } from "./pmToAm"
+


### PR DESCRIPTION
Exports methods to convert AutoMerge to ProseMirror (blocksFromNode), and ProseMirror to AutoMerge (docFromSpans).

Examples

```js
const markdown = '# Markdown here'
const pmJSON = defaultMarkdownParser.parse(markdown).toJSON()
const spans = blocksFromNode(basicSchemaAdapter, pmJSON)
changeDoc(doc => {
  am.updateSpans(doc, 'content', spans)
})
```

```js
const doc = docFromSpans(basicSchemaAdapter, am.spans(doc, 'content'))
```

y-prosemirror has similar methods:
https://github.com/yjs/y-prosemirror/blob/fd08cf3c7c307c1446178765baa94603a3a8416a/src/lib.js#L254
https://github.com/yjs/y-prosemirror/blob/fd08cf3c7c307c1446178765baa94603a3a8416a/src/lib.js#L331