### PR TITLE
fix removeMark

### DIFF
--- a/src/amToPm.ts
+++ b/src/amToPm.ts
@@ -112,15 +112,19 @@ function handleMark(
       const pmEnd = amSpliceIdxToPmIdx(adapter, spans, mark.end)
       if (pmStart == null || pmEnd == null) throw new Error("Invalid index")
       if (mark.value == null) {
-        const markMapping = adapter.markMappings.find(m => m.automergeMarkName === mark.name);
-        const markType = markMapping ? markMapping.prosemirrorMark : adapter.unknownMark;
-        tx = tx.removeMark(pmStart, pmEnd, markType);
+        const markMapping = adapter.markMappings.find(
+          m => m.automergeMarkName === mark.name,
+        )
+        const markType = markMapping
+          ? markMapping.prosemirrorMark
+          : adapter.unknownMark
+        tx = tx.removeMark(pmStart, pmEnd, markType)
       } else {
         const pmMarks = pmMarksFromAmMarks(adapter, {
           [mark.name]: mark.value,
-        });
+        })
         for (const pmMark of pmMarks) {
-          tx = tx.addMark(pmStart, pmEnd, pmMark);
+          tx = tx.addMark(pmStart, pmEnd, pmMark)
         }
       }
     }

--- a/src/amToPm.ts
+++ b/src/amToPm.ts
@@ -111,11 +111,17 @@ function handleMark(
       const pmStart = amSpliceIdxToPmIdx(adapter, spans, mark.start)
       const pmEnd = amSpliceIdxToPmIdx(adapter, spans, mark.end)
       if (pmStart == null || pmEnd == null) throw new Error("Invalid index")
-      const pmMarks = pmMarksFromAmMarks(adapter, {
-        [mark.name]: mark.value,
-      })
-      for (const pmMark of pmMarks) {
-        tx = tx.addMark(pmStart, pmEnd, pmMark)
+      if (mark.value == null) {
+        const markMapping = adapter.markMappings.find(m => m.automergeMarkName === mark.name);
+        const markType = markMapping ? markMapping.prosemirrorMark : adapter.unknownMark;
+        tx = tx.removeMark(pmStart, pmEnd, markType);
+      } else {
+        const pmMarks = pmMarksFromAmMarks(adapter, {
+          [mark.name]: mark.value,
+        });
+        for (const pmMark of pmMarks) {
+          tx = tx.addMark(pmStart, pmEnd, pmMark);
+        }
       }
     }
   }

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -265,7 +265,7 @@ export function pmMarksFromAmMarks(
 
   for (const [markName, markValue] of Object.entries(amMarks)) {
     // Filter tombstoned marks (https://github.com/automerge/automerge/issues/715).
-		if (markValue == null) continue;
+    if (markValue == null) continue
     const mapping = adapter.markMappings.find(
       m => m.automergeMarkName === markName,
     )

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -264,6 +264,9 @@ export function pmMarksFromAmMarks(
   const pmMarks = []
 
   for (const [markName, markValue] of Object.entries(amMarks)) {
+		if (markValue == null) {
+			throw new Error("Cannot create pmMark from null markValue");
+		}
     const mapping = adapter.markMappings.find(
       m => m.automergeMarkName === markName,
     )

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -264,9 +264,8 @@ export function pmMarksFromAmMarks(
   const pmMarks = []
 
   for (const [markName, markValue] of Object.entries(amMarks)) {
-		if (markValue == null) {
-			throw new Error("Cannot create pmMark from null markValue");
-		}
+    // Filter tombstoned marks (https://github.com/automerge/automerge/issues/715).
+		if (markValue == null) continue;
     const mapping = adapter.markMappings.find(
       m => m.automergeMarkName === markName,
     )


### PR DESCRIPTION
Removing marks broke with #8, specifically within the `handleMark` function.

https://github.com/automerge/automerge-prosemirror/commit/d1abb5c7025a78936d4928f51b961459e3316329#diff-1cdd5cad54822249d22829cef95393e37707fcdb58e789e1a217c9f847ff9d9aL114-L120

This PR reimplements removing marks by checking if mark value is null, which is the only way we know that a mark is deleted as the MarkPatch type is not that expressive ([Peritext has separate AddMark and RemoveMark patches](https://github.com/inkandswitch/peritext/blob/89c162d3c1ae02c426c9002419aef0814e779ed8/src/micromerge.ts#L25)).

```ts
type MarkPatch = {
	action: 'mark';
	path: Prop[];
	marks: am.Mark[];
};
```

Slightly awkward with ProseMirror's API, as you _can_ [create a mark passing in null](https://prosemirror.net/docs/ref/#model.MarkType.create) (defaultAttrs is used to fill in missing attrs).


Fixes #12 