### PR TITLE
handle non-text selections

### DIFF
--- a/playground/src/Editor.tsx
+++ b/playground/src/Editor.tsx
@@ -97,6 +97,12 @@ function turnSelectionIntoBlockquote(
   return true
 }
 
+declare global {
+  interface Node {
+    view?: EditorView
+  }
+}
+
 export function Editor({ handle, path, schemaAdapter }: EditorProps) {
   const editorRoot = useRef<HTMLDivElement>(null)
   const [view, setView] = useState<EditorView | null>(null)
@@ -164,6 +170,8 @@ export function Editor({ handle, path, schemaAdapter }: EditorProps) {
 
     setView(view)
 
+    // Attach view to mount for testing
+    if (editorRoot.current) editorRoot.current.view = view
     return () => {
       handle.off("change", onPatch)
       view.destroy()

--- a/playground/src/Playground.tsx
+++ b/playground/src/Playground.tsx
@@ -12,7 +12,6 @@ import {
 } from "../../src"
 import { Mark, Node } from "prosemirror-model"
 import { BlockMarker } from "../../src/types"
-import { next as am } from "@automerge/automerge"
 
 const { port1: leftToRight, port2: rightToLeft } = new MessageChannel()
 

--- a/src/intercept.ts
+++ b/src/intercept.ts
@@ -32,19 +32,13 @@ export function intercept<T>(
   // Get the corresponding patches and turn them into a transaction to apply to the editorstate
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const diff = am.diff(handle.docSync()!, headsBefore, headsAfter)
-  //console.log("Intercept diff: ")
-  //console.log(diff)
 
   // Create a transaction which applies the diff and updates the doc and heads
   let tx = amToPm(adapter, materializedSpans, diff, path, state.tr)
   const nonInterceptedAfter = state.apply(intercepted)
   const selectionAfter = nonInterceptedAfter.selection
   try {
-    const resolvedSelectionAfter = new TextSelection(
-      tx.doc.resolve(selectionAfter.from),
-      tx.doc.resolve(selectionAfter.to),
-    )
-    tx = tx.setSelection(resolvedSelectionAfter)
+		tx.setSelection(Selection.fromJSON(tx.doc, selectionAfter.toJSON()));
   } catch (e) {
     if (e instanceof RangeError) {
       // Sometimes the selection can't be mapped for some reason so we just give up and hope for the best
@@ -52,9 +46,7 @@ export function intercept<T>(
       throw e
     }
   }
-
-  tx = tx.setStoredMarks(nonInterceptedAfter.storedMarks)
-
+  tx.setStoredMarks(nonInterceptedAfter.storedMarks)
   return state.apply(tx)
 }
 

--- a/src/intercept.ts
+++ b/src/intercept.ts
@@ -34,7 +34,7 @@ export function intercept<T>(
   const diff = am.diff(handle.docSync()!, headsBefore, headsAfter)
 
   // Create a transaction which applies the diff and updates the doc and heads
-  let tx = amToPm(adapter, materializedSpans, diff, path, state.tr)
+  const tx = amToPm(adapter, materializedSpans, diff, path, state.tr)
   const nonInterceptedAfter = state.apply(intercepted)
   const selectionAfter = nonInterceptedAfter.selection
   try {

--- a/src/intercept.ts
+++ b/src/intercept.ts
@@ -38,7 +38,7 @@ export function intercept<T>(
   const nonInterceptedAfter = state.apply(intercepted)
   const selectionAfter = nonInterceptedAfter.selection
   try {
-		tx.setSelection(Selection.fromJSON(tx.doc, selectionAfter.toJSON()));
+    tx.setSelection(Selection.fromJSON(tx.doc, selectionAfter.toJSON()))
   } catch (e) {
     if (e instanceof RangeError) {
       // Sometimes the selection can't be mapped for some reason so we just give up and hope for the best

--- a/src/intercept.ts
+++ b/src/intercept.ts
@@ -1,5 +1,5 @@
 import { next as am } from "@automerge/automerge"
-import { EditorState, Transaction, TextSelection } from "prosemirror-state"
+import { EditorState, Transaction, Selection } from "prosemirror-state"
 import pmToAm from "./pmToAm"
 import amToPm from "./amToPm"
 import { DocHandle } from "./types"


### PR DESCRIPTION
Noticed `AllSelection` and other selections were being improperly replaced by a text selection. This uses a [ProseMirror method](https://prosemirror.net/docs/ref/#state.Selection^fromJSON) to restore the selection if the transaction wasn't intercepted by Automerge.

![CleanShot 2024-08-13 at 21 59 13](https://github.com/user-attachments/assets/24af7be1-e0fe-4f02-bade-30a10a90e438)

Wonder if we can add tests that uses [`state.apply(intercepted)`](https://github.com/automerge/automerge-prosemirror/blob/08612db748290d371ae053a7b5831309cd2d65c6/src/intercept.ts#L40) to check editor state after applying the transformed amToPm tx.
