### PR TITLE
Refactor initialization to make it easier to get started

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,13 @@
-export { type DocHandle } from "./types.js"
+import { next as A } from "@automerge/automerge/slim"
+import { Node, Schema } from "prosemirror-model"
+import { Plugin } from "prosemirror-state"
+import { DocHandle } from "./DocHandle.js"
+import { SchemaAdapter } from "./schema.js"
+import { basicSchemaAdapter } from "./basicSchema.js"
+import { pmDocFromSpans } from "./traversal.js"
+import { syncPlugin } from "./syncPlugin.js"
+export { type DocHandle }
+
 export {
   SchemaAdapter,
   type MappedSchemaSpec,
@@ -9,3 +18,70 @@ export {
 export { basicSchemaAdapter } from "./basicSchema.js"
 export { pmDocFromSpans, pmNodeToSpans } from "./traversal.js"
 export { syncPlugin, syncPluginKey } from "./syncPlugin.js"
+
+/**
+ * Initialize a ProseMirror document, schema, and plugin from an Automerge document
+ *
+ * @remarks
+ * This function is used to create the initial ProseMirror schema, plugin, and document which you
+ * pass to the ProseMirror Editor. If your text uses the
+ * {@link https://automerge.org/docs/under-the-hood/rich_text_schema/ | default schema}
+ * Then you can just pass the document handle and a path to the text field in the document,
+ * otherwise you can pass the `schemaAdapter` option with your own adapter.
+ *
+ * @param handle - The DocHandle containing the text to edit
+ * @param pathToTextField - The path to the text field in the automerge document
+ * @param options - Additional options, this is where you can pass a custom schema adapter
+ *
+ * @returns A ProseMirror Schema, Node, and Plugin ready to pass to the ProseMirror Editor
+ *
+ * @example
+ * Here's an example of basic usage for editing the description of a todo item
+ *
+ * ```ts
+ * import { next as A } from "@automerge/automerge"
+ * import { init } from "automerge-prosemirror"
+ * import { EditorState } from "prosemirror-state"
+ *
+ * const repo = new Repo({network: []})
+ * const handle = repo.create({ items: [{ description: "Hello World" }] })
+
+ * const { schema, pmDoc, plugin } = init(amDoc, ["items", 0, "description"])
+ * const state = EditorState.create({ schema, doc: pmDoc, plugins: [plugin] })
+ * ```
+ *
+ * @example
+ * Here's an example of using a custom schema adapter
+ *
+ * ```ts
+ * import { Repo } from "@automerge/automerge-repo"
+ * import { initPmDoc, SchemaAdapter } from "automerge-prosemirror"
+ * import { EditorState } from "prosemirror-state"
+ *
+ * const repo = new Repo({network: []})
+ * const handle = repo.create({ items: [{ description: "Hello World" }] })
+ *
+ * // Create and pass the custom schema adapter
+ * const adapter = new SchemaAdapter( ... )
+ * const { schema, pmDoc, plugin } = init(amDoc, ["items", 0, "description"], { schemaAdapter: adapter })
+ *
+ * const state = EditorState.create({ schema, doc: pmDoc, plugins: [plugin] })
+ * ```
+ */
+export function init(
+  handle: DocHandle<unknown>,
+  pathToTextField: A.Prop[],
+  options: { schemaAdapter: SchemaAdapter } | undefined = undefined,
+): { schema: Schema; pmDoc: Node; plugin: Plugin } {
+  const adapter = options?.schemaAdapter ?? basicSchemaAdapter
+  const doc = handle.docSync()
+  if (!doc) {
+    throw new Error(
+      "cannot initialize ProseMirror document when handle is not ready",
+    )
+  }
+  const spans = A.spans(doc, pathToTextField)
+  const pmDoc = pmDocFromSpans(adapter, spans)
+  const plugin = syncPlugin({ adapter, handle, path: pathToTextField })
+  return { schema: adapter.schema, pmDoc, plugin }
+}


### PR DESCRIPTION
Problem: The initialization of this library requires a lot of familiarity with the various moving parts. This makes it difficult to get started. 

Solution: Add an init function which gives users the three things they need: a schema, a prosemirror document, and a plugin. These things can be passed straight to the Editor component without needing to understand how they all fit together.

@BrianHung I would appreciate your thoughts on this as you've done a bunch of work on the plugin side.