### PR TITLE
Conform `init()` type to ProseMirror `EditorState.create()`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -81,7 +81,7 @@ export function init(
     )
   }
   const spans = A.spans(doc, pathToTextField)
-  const pmDoc = pmDocFromSpans(adapter, spans)
+  const doc = pmDocFromSpans(adapter, spans)
   const plugin = syncPlugin({ adapter, handle, path: pathToTextField })
-  return { schema: adapter.schema, pmDoc, plugin }
+  return { schema: adapter.schema, doc, plugin }
 }


### PR DESCRIPTION
A change here means there is no more need for:
https://github.com/automerge/automerge.github.io/pull/99#pullrequestreview-2436880654