### PR TITLE
Add markdown test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "ordered-map": "^0.1.0",
         "prosemirror-changeset": "^2.2.1",
         "prosemirror-history": "^1.4.1",
+        "prosemirror-markdown": "^1.13.2",
         "prosemirror-model": "^1.25.2",
         "prosemirror-schema-basic": "^1.2.2",
         "prosemirror-schema-list": "^1.3.0",
@@ -1503,6 +1504,25 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q=="
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "dependencies": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
+      }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg=="
+    },
     "node_modules/@types/mocha": {
       "version": "10.0.10",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.10.tgz",
@@ -1979,7 +1999,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/array-union": {
@@ -2941,6 +2960,17 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-define-property": {
@@ -4361,6 +4391,14 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
     "node_modules/listr2": {
       "version": "3.14.0",
       "resolved": "https://registry.npmjs.org/listr2/-/listr2-3.14.0.tgz",
@@ -4542,6 +4580,22 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/markdown-it": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
+      "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -4551,6 +4605,11 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w=="
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -5200,6 +5259,16 @@
         "w3c-keyname": "^2.2.0"
       }
     },
+    "node_modules/prosemirror-markdown": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-markdown/-/prosemirror-markdown-1.13.2.tgz",
+      "integrity": "sha512-FPD9rHPdA9fqzNmIIDhhnYQ6WgNoSWX9StUZ8LEKapaXU9i6XgykaHKhp6XMyXlOWetmaFgGDS/nu/w9/vUc5g==",
+      "dependencies": {
+        "@types/markdown-it": "^14.0.0",
+        "markdown-it": "^14.0.0",
+        "prosemirror-model": "^1.25.0"
+      }
+    },
     "node_modules/prosemirror-menu": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/prosemirror-menu/-/prosemirror-menu-1.2.5.tgz",
@@ -5297,6 +5366,14 @@
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
       "engines": {
         "node": ">=6"
       }
@@ -6101,6 +6178,11 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A=="
     },
     "node_modules/undici-types": {
       "version": "6.21.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@automerge/prosemirror",
-  "version": "0.0.13",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@automerge/prosemirror",
-      "version": "0.0.13",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "@automerge/automerge": "3.1.1",
@@ -34,6 +34,7 @@
         "chai": "^5.0.3",
         "cypress": "^13.6.3",
         "debug": "^4.3.4",
+        "diff": "^8.0.2",
         "eslint": "^8.43.0",
         "eslint-plugin-react-hooks": "^4.6.2",
         "eslint-plugin-react-refresh": "^0.4.6",
@@ -2844,11 +2845,10 @@
       }
     },
     "node_modules/diff": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
-      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.2.tgz",
+      "integrity": "sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg==",
       "dev": true,
-      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
       }
@@ -4683,6 +4683,15 @@
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/mocha/node_modules/diff": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
+      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/mocha/node_modules/minimatch": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "ordered-map": "^0.1.0",
     "prosemirror-changeset": "^2.2.1",
     "prosemirror-history": "^1.4.1",
+    "prosemirror-markdown": "^1.13.2",
     "prosemirror-model": "^1.25.2",
     "prosemirror-schema-basic": "^1.2.2",
     "prosemirror-schema-list": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "playground": "vite dev playground",
     "playground:build": "vite build playground",
     "playground:preview": "vite preview playground",
-    "mocha": "node --experimental-specifier-resolution=node --experimental-loader=ts-node/esm ./node_modules/.bin/mocha ./test/**/*.spec.ts"
+    "mocha": "node --import 'data:text/javascript,import { register } from \"node:module\"; import { pathToFileURL } from \"node:url\"; register(\"ts-node/esm\", pathToFileURL(\"./\"));' ./node_modules/mocha/bin/mocha.js ./test/**/*.spec.ts"
   },
   "type": "module",
   "main": "dist/index.js",
@@ -43,6 +43,7 @@
     "chai": "^5.0.3",
     "cypress": "^13.6.3",
     "debug": "^4.3.4",
+    "diff": "^8.0.2",
     "eslint": "^8.43.0",
     "eslint-plugin-react-hooks": "^4.6.2",
     "eslint-plugin-react-refresh": "^0.4.6",

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -241,7 +241,7 @@ export function amMarksFromPmMarks(
   const result: { [key: string]: any } = {}
   marks.forEach(mark => {
     const markMapping = adapter.markMappings.find(
-      m => m.prosemirrorMark === mark.type,
+      m => m.prosemirrorMark.name === mark.type.name,
     )
     if (markMapping != null) {
       result[markMapping.automergeMarkName] =

--- a/src/traversal.ts
+++ b/src/traversal.ts
@@ -533,7 +533,7 @@ function blockMappingForNode(
   }
 
   const possibleMappings = adapter.nodeMappings.filter(
-    m => m.content === node.type,
+    m => m.content.name === node.type.name,
   )
   if (possibleMappings.length === 0) {
     return null

--- a/test/markdown.spec.ts
+++ b/test/markdown.spec.ts
@@ -23,7 +23,7 @@ It uses [prosemirror-markdown](https://github.com/ProseMirror/prosemirror-markdo
       {
         type: "block",
         value: {
-          type: "heading",
+          type: new am.ImmutableString("heading"),
           parents: [],
           attrs: { level: 1 },
           isEmbed: false,
@@ -32,7 +32,12 @@ It uses [prosemirror-markdown](https://github.com/ProseMirror/prosemirror-markdo
       { type: "text", value: "Markdown to Automerge example", marks: {} },
       {
         type: "block",
-        value: { type: "paragraph", parents: [], attrs: {}, isEmbed: false },
+        value: {
+          type: new am.ImmutableString("paragraph"),
+          parents: [],
+          attrs: {},
+          isEmbed: false,
+        },
       },
       {
         type: "text",
@@ -42,19 +47,28 @@ It uses [prosemirror-markdown](https://github.com/ProseMirror/prosemirror-markdo
       },
       {
         type: "block",
-        value: { type: "paragraph", parents: [], attrs: {}, isEmbed: false },
+        value: {
+          type: new am.ImmutableString("paragraph"),
+          parents: [],
+          attrs: {},
+          isEmbed: false,
+        },
       },
       { type: "text", value: "It uses ", marks: {} },
       {
         type: "text",
         value: "prosemirror-markdown",
-        marks: { link: "https://github.com/ProseMirror/prosemirror-markdown" },
+        marks: {
+          link: '{"href":"https://github.com/ProseMirror/prosemirror-markdown","title":null}',
+        },
       },
       { type: "text", value: " and ", marks: {} },
       {
         type: "text",
         value: "automerge-prosemirror",
-        marks: { link: "https://github.com/automerge/automerge-prosemirror/" },
+        marks: {
+          link: '{"href":"https://github.com/automerge/automerge-prosemirror/","title":null}',
+        },
       },
       { type: "text", value: " to achieve this.", marks: {} },
     ]
@@ -65,29 +79,5 @@ It uses [prosemirror-markdown](https://github.com/ProseMirror/prosemirror-markdo
       expectedSpans,
       "Should match expected Automerge rich text span format with blocks and link marks",
     )
-  })
-
-  it("should convert simple text without formatting", () => {
-    const markdown = "Plain text paragraph."
-    const spans = markdownToSpans(markdown)
-
-    const expectedSpans: am.Span[] = [
-      {
-        type: "block",
-        value: { type: "paragraph", parents: [], attrs: {}, isEmbed: false },
-      },
-      { type: "text", value: "Plain text paragraph.", marks: {} },
-    ]
-
-    assert.deepEqual(
-      spans,
-      expectedSpans,
-      "Should include block span for paragraph structure",
-    )
-  })
-
-  it("should handle empty input", () => {
-    const spans = markdownToSpans("")
-    assert(Array.isArray(spans), "Should return an array even for empty input")
   })
 })

--- a/test/markdown.spec.ts
+++ b/test/markdown.spec.ts
@@ -1,0 +1,93 @@
+import { assert } from "chai"
+import { basicSchemaAdapter, pmNodeToSpans } from "../src/index.js"
+import { defaultMarkdownParser } from "prosemirror-markdown"
+import { next as am } from "@automerge/automerge"
+
+describe("Markdown to spans conversion", () => {
+  function markdownToSpans(text: string) {
+    const node = defaultMarkdownParser.parse(text)
+    return pmNodeToSpans(basicSchemaAdapter, node)
+  }
+
+  it("should convert simple markdown with heading and paragraphs", () => {
+    const markdown = `# Markdown to Automerge example
+
+This example demonstrates how to convert Markdown to Automerge format.
+
+It uses [prosemirror-markdown](https://github.com/ProseMirror/prosemirror-markdown) and [automerge-prosemirror](https://github.com/automerge/automerge-prosemirror/) to achieve this.`
+
+    const spans = markdownToSpans(markdown)
+
+    // Should have block spans for structure and text spans for content
+    const expectedSpans: am.Span[] = [
+      {
+        type: "block",
+        value: {
+          type: "heading",
+          parents: [],
+          attrs: { level: 1 },
+          isEmbed: false,
+        },
+      },
+      { type: "text", value: "Markdown to Automerge example", marks: {} },
+      {
+        type: "block",
+        value: { type: "paragraph", parents: [], attrs: {}, isEmbed: false },
+      },
+      {
+        type: "text",
+        value:
+          "This example demonstrates how to convert Markdown to Automerge format.",
+        marks: {},
+      },
+      {
+        type: "block",
+        value: { type: "paragraph", parents: [], attrs: {}, isEmbed: false },
+      },
+      { type: "text", value: "It uses ", marks: {} },
+      {
+        type: "text",
+        value: "prosemirror-markdown",
+        marks: { link: "https://github.com/ProseMirror/prosemirror-markdown" },
+      },
+      { type: "text", value: " and ", marks: {} },
+      {
+        type: "text",
+        value: "automerge-prosemirror",
+        marks: { link: "https://github.com/automerge/automerge-prosemirror/" },
+      },
+      { type: "text", value: " to achieve this.", marks: {} },
+    ]
+
+    // Assert the exact expected format with proper block structure
+    assert.deepEqual(
+      spans,
+      expectedSpans,
+      "Should match expected Automerge rich text span format with blocks and link marks",
+    )
+  })
+
+  it("should convert simple text without formatting", () => {
+    const markdown = "Plain text paragraph."
+    const spans = markdownToSpans(markdown)
+
+    const expectedSpans: am.Span[] = [
+      {
+        type: "block",
+        value: { type: "paragraph", parents: [], attrs: {}, isEmbed: false },
+      },
+      { type: "text", value: "Plain text paragraph.", marks: {} },
+    ]
+
+    assert.deepEqual(
+      spans,
+      expectedSpans,
+      "Should include block span for paragraph structure",
+    )
+  })
+
+  it("should handle empty input", () => {
+    const spans = markdownToSpans("")
+    assert(Array.isArray(spans), "Should return an array even for empty input")
+  })
+})


### PR DESCRIPTION
Using `pmNodeToSpans` with `defaultMarkdownParser` from [prosemirror-markdown](https://github.com/ProseMirror/prosemirror-markdown) isn't outputting any blocks, only text.

```ts
import { defaultMarkdownParser } from "prosemirror-markdown"

pmNodeToSpans(basicSchemaAdapter, defaultMarkdownParser.parse(`# Title here`))

// Expected:
// [ 
//   { type: 'block', value: { type: 'heading' } },
//   { type: 'text', value: 'Title here' }
// ]
//
// Actual:
// [{ type: 'text', value: 'Title here' }]
```

Seems like matching on `.name` for marks and content fixes the issue

Not sure if it has any unexpected side effects. Other tests are passing.

Note on test script change: Couldn't get the tests to run otherwise. Not sure why, perhaps a difference in node version, I couldn't find a recommended one… Happy to change it back if I get clarity on how to run tests