### PR TITLE
Block embed fix

### DIFF
--- a/src/basicSchema.ts
+++ b/src/basicSchema.ts
@@ -74,6 +74,10 @@ const basicSchema: MappedSchemaSpec = {
 
     /// A horizontal rule (`<hr>`).
     horizontal_rule: {
+      automerge: {
+        block: "__ext__horizontal-rule",
+        isEmbed: true,
+      },
       group: "block",
       parseDOM: [{ tag: "hr" }],
       toDOM() {

--- a/src/traversal.ts
+++ b/src/traversal.ts
@@ -640,6 +640,31 @@ class TraverseState {
         block.type.val,
         block.isEmbed,
       )
+
+      // For block-level embeds, we need to close any open inline containers
+      if (content.isBlock) {
+        // Close any open inline/textblock containers that can't contain blocks
+        let closeCount = 0
+        for (let i = this.stack.length - 1; i >= 0; i--) {
+          const frame = this.stack[i]
+          // Check if this node can contain block content by testing its content match
+          const canContainBlock = frame.node.contentMatch.matchType(content)
+          if (!canContainBlock) {
+            closeCount++
+          } else {
+            break
+          }
+        }
+
+        if (closeCount > 0) {
+          const toClose = this.stack.splice(this.stack.length - closeCount)
+          for (const { node, role, lastMatch } of toClose.toReversed()) {
+            yield* this.finishStackFrame({ node, role, lastMatch })
+            yield { type: "closeTag", tag: node.name, role }
+          }
+        }
+      }
+
       const wrapping = this.currentMatch.findWrapping(content)
       if (wrapping) {
         for (let i = 0; i < wrapping.length; i++) {

--- a/test/traversal.spec.ts
+++ b/test/traversal.spec.ts
@@ -17,6 +17,60 @@ import { AssertionError } from "assert"
 import { basicSchemaAdapter } from "../src/basicSchema.js"
 
 describe("the traversal API", () => {
+  describe("horizontal rule embed handling", () => {
+    it("should handle hr blocks without throwing 'Match cannot be null' error", () => {
+      // Create a simple document with an hr block
+      const spans: am.Span[] = [
+        {
+          type: "block",
+          value: {
+            type: new am.ImmutableString("__ext__horizontal-rule"),
+            parents: [],
+            attrs: {},
+            isEmbed: true
+          }
+        }
+      ]
+      
+      // This should not throw an error
+      const doc = pmDocFromSpans(basicSchemaAdapter, spans)
+      
+      // Verify the document structure
+      assert.equal(doc.type.name, "doc")
+      assert.equal(doc.childCount, 1)
+      assert.equal(doc.child(0).type.name, "horizontal_rule")
+    })
+    
+    it("should properly close paragraphs when inserting hr blocks", () => {
+      // Create a document with text followed by an hr
+      const spans: am.Span[] = [
+        {
+          type: "text",
+          value: "Some text before hr"
+        },
+        {
+          type: "block", 
+          value: {
+            type: new am.ImmutableString("__ext__horizontal-rule"),
+            parents: [],
+            attrs: {},
+            isEmbed: true
+          }
+        }
+      ]
+      
+      // This should not throw 'Invalid content for node paragraph: <horizontal_rule>'
+      const doc = pmDocFromSpans(basicSchemaAdapter, spans)
+      
+      // Verify the document structure
+      assert.equal(doc.type.name, "doc")
+      assert.equal(doc.childCount, 2)
+      assert.equal(doc.child(0).type.name, "paragraph")
+      assert.equal(doc.child(0).textContent, "Some text before hr")
+      assert.equal(doc.child(1).type.name, "horizontal_rule")
+    })
+  })
+
   describe("the amSpliceIdxToPmIdx function", () => {
     it("should return the last prosemirror text index before the given automerge index", () => {
       const { spans } = docFromBlocksNotation([


### PR DESCRIPTION
Fixes #25 

Based on latest published package (v0.1.0) #33 

- Add automerge adapter schema for horizontal rule
- Add failing test
- Fix issue with `newBlock` in `traversal.ts`

