### PR TITLE
Fix matching in mark and block mappings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@automerge/prosemirror",
-  "version": "0.0.13",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@automerge/prosemirror",
-      "version": "0.0.13",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "@automerge/automerge": "3.1.1",
@@ -46,6 +46,7 @@
         "prosemirror-example-setup": "^1.2.2",
         "prosemirror-inputrules": "^1.4.0",
         "prosemirror-keymap": "^1.2.2",
+        "prosemirror-markdown": "^1.13.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "ts-node": "^10.9.2",
@@ -1502,6 +1503,28 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "dev": true
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "dev": true,
+      "dependencies": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
+      }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "dev": true
+    },
     "node_modules/@types/mocha": {
       "version": "10.0.10",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.10.tgz",
@@ -2943,6 +2966,18 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -4361,6 +4396,15 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "dev": true,
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
     "node_modules/listr2": {
       "version": "3.14.0",
       "resolved": "https://registry.npmjs.org/listr2/-/listr2-3.14.0.tgz",
@@ -4542,6 +4586,23 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/markdown-it": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
+      "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -4551,6 +4612,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "dev": true
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -5191,6 +5258,17 @@
         "w3c-keyname": "^2.2.0"
       }
     },
+    "node_modules/prosemirror-markdown": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-markdown/-/prosemirror-markdown-1.13.2.tgz",
+      "integrity": "sha512-FPD9rHPdA9fqzNmIIDhhnYQ6WgNoSWX9StUZ8LEKapaXU9i6XgykaHKhp6XMyXlOWetmaFgGDS/nu/w9/vUc5g==",
+      "dev": true,
+      "dependencies": {
+        "@types/markdown-it": "^14.0.0",
+        "markdown-it": "^14.0.0",
+        "prosemirror-model": "^1.25.0"
+      }
+    },
     "node_modules/prosemirror-menu": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/prosemirror-menu/-/prosemirror-menu-1.2.5.tgz",
@@ -5288,6 +5366,15 @@
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -6092,6 +6179,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "dev": true
     },
     "node_modules/undici-types": {
       "version": "6.21.0",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "prosemirror-example-setup": "^1.2.2",
     "prosemirror-inputrules": "^1.4.0",
     "prosemirror-keymap": "^1.2.2",
+    "prosemirror-markdown": "^1.13.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "ts-node": "^10.9.2",

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -241,7 +241,7 @@ export function amMarksFromPmMarks(
   const result: { [key: string]: any } = {}
   marks.forEach(mark => {
     const markMapping = adapter.markMappings.find(
-      m => m.prosemirrorMark === mark.type,
+      m => m.prosemirrorMark.name === mark.type.name,
     )
     if (markMapping != null) {
       result[markMapping.automergeMarkName] =

--- a/src/traversal.ts
+++ b/src/traversal.ts
@@ -533,7 +533,7 @@ function blockMappingForNode(
   }
 
   const possibleMappings = adapter.nodeMappings.filter(
-    m => m.content === node.type,
+    m => m.content.name === node.type.name,
   )
   if (possibleMappings.length === 0) {
     return null

--- a/test/markdown.spec.ts
+++ b/test/markdown.spec.ts
@@ -1,0 +1,83 @@
+import { assert } from "chai"
+import { basicSchemaAdapter, pmNodeToSpans } from "../src/index.js"
+import { defaultMarkdownParser } from "prosemirror-markdown"
+import { next as am } from "@automerge/automerge"
+
+describe("Markdown to spans conversion", () => {
+  function markdownToSpans(text: string) {
+    const node = defaultMarkdownParser.parse(text)
+    return pmNodeToSpans(basicSchemaAdapter, node)
+  }
+
+  it("should convert simple markdown with heading and paragraphs", () => {
+    const markdown = `# Markdown to Automerge example
+
+This example demonstrates how to convert Markdown to Automerge format.
+
+It uses [prosemirror-markdown](https://github.com/ProseMirror/prosemirror-markdown) and [automerge-prosemirror](https://github.com/automerge/automerge-prosemirror/) to achieve this.`
+
+    const spans = markdownToSpans(markdown)
+
+    // Should have block spans for structure and text spans for content
+    const expectedSpans: am.Span[] = [
+      {
+        type: "block",
+        value: {
+          type: new am.ImmutableString("heading"),
+          parents: [],
+          attrs: { level: 1 },
+          isEmbed: false,
+        },
+      },
+      { type: "text", value: "Markdown to Automerge example", marks: {} },
+      {
+        type: "block",
+        value: {
+          type: new am.ImmutableString("paragraph"),
+          parents: [],
+          attrs: {},
+          isEmbed: false,
+        },
+      },
+      {
+        type: "text",
+        value:
+          "This example demonstrates how to convert Markdown to Automerge format.",
+        marks: {},
+      },
+      {
+        type: "block",
+        value: {
+          type: new am.ImmutableString("paragraph"),
+          parents: [],
+          attrs: {},
+          isEmbed: false,
+        },
+      },
+      { type: "text", value: "It uses ", marks: {} },
+      {
+        type: "text",
+        value: "prosemirror-markdown",
+        marks: {
+          link: '{"href":"https://github.com/ProseMirror/prosemirror-markdown","title":null}',
+        },
+      },
+      { type: "text", value: " and ", marks: {} },
+      {
+        type: "text",
+        value: "automerge-prosemirror",
+        marks: {
+          link: '{"href":"https://github.com/automerge/automerge-prosemirror/","title":null}',
+        },
+      },
+      { type: "text", value: " to achieve this.", marks: {} },
+    ]
+
+    // Assert the exact expected format with proper block structure
+    assert.deepEqual(
+      spans,
+      expectedSpans,
+      "Should match expected Automerge rich text span format with blocks and link marks",
+    )
+  })
+})


### PR DESCRIPTION
- Add failing markdown parse tests
- Fix by matching on `.name` instead of object in `amMarksFromPmMarks` and `blockMappingForNode`

This is a cleaned up version of #45 – more info in there on the background for this