### PR TITLE
Add debug view to Playground

### DIFF
--- a/playground/src/Editor.tsx
+++ b/playground/src/Editor.tsx
@@ -58,6 +58,7 @@ export type EditorProps = {
   handle: DocHandle<unknown>
   path: Prop[]
   schemaAdapter: SchemaAdapter
+  onStateChange?: (state: EditorState) => void;
 }
 
 const toggleBold = (schema: Schema) => toggleMarkCommand(schema.marks.strong)
@@ -97,8 +98,9 @@ function turnSelectionIntoBlockquote(
   return true
 }
 
-export function Editor({ handle, path, schemaAdapter }: EditorProps) {
+export function Editor({ handle, path, schemaAdapter, onStateChange }: EditorProps) {
   const editorRoot = useRef<HTMLDivElement>(null)
+  const onChange = useRef(onStateChange);
   const [view, setView] = useState<EditorView | null>(null)
   const [imageModalOpen, setImageModalOpen] = useState(false)
   const [linkModalOpen, setLinkModalOpen] = useState(false)
@@ -140,6 +142,7 @@ export function Editor({ handle, path, schemaAdapter }: EditorProps) {
       dispatchTransaction(this: EditorView, tr: Transaction) {
         const newState = this.state.apply(tr)
         this.updateState(newState)
+        onChange.current?.(newState)
         setMarkState(activeMarks(newState, schema))
       },
     })

--- a/playground/src/Editor.tsx
+++ b/playground/src/Editor.tsx
@@ -58,7 +58,7 @@ export type EditorProps = {
   handle: DocHandle<unknown>
   path: Prop[]
   schemaAdapter: SchemaAdapter
-  onStateChange?: (state: EditorState) => void;
+  onStateChange?: (state: EditorState) => void
 }
 
 const toggleBold = (schema: Schema) => toggleMarkCommand(schema.marks.strong)
@@ -98,9 +98,14 @@ function turnSelectionIntoBlockquote(
   return true
 }
 
-export function Editor({ handle, path, schemaAdapter, onStateChange }: EditorProps) {
+export function Editor({
+  handle,
+  path,
+  schemaAdapter,
+  onStateChange,
+}: EditorProps) {
   const editorRoot = useRef<HTMLDivElement>(null)
-  const onChange = useRef(onStateChange);
+  const onChange = useRef(onStateChange)
   const [view, setView] = useState<EditorView | null>(null)
   const [imageModalOpen, setImageModalOpen] = useState(false)
   const [linkModalOpen, setLinkModalOpen] = useState(false)

--- a/playground/src/Playground.tsx
+++ b/playground/src/Playground.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react"
 import { Editor } from "./Editor"
-import { Repo, DocHandle } from "@automerge/automerge-repo"
+import { Repo, DocHandle, DocHandleChangePayload } from "@automerge/automerge-repo"
 //import { MessageChannelNetworkAdapter } from "@automerge/automerge-repo-network-messagechannel"
 import { PausableNetworkAdapter } from "./PausableNetworkAdapter"
 import TabContainer from "./Tabs"
@@ -188,12 +188,23 @@ function DebugEditor({
   debug?: boolean
 }) {
   const [spans, setSpans] = useState(Automerge.spans(handle.doc(), path))
-  handle.on("change", (payload) => {
-    setSpans(Automerge.spans(payload.doc, ["text"]))
-  })
+  useEffect(() => {
+    if (!debug) {
+      return;
+    }
+    function listener(payload: DocHandleChangePayload<unknown>) {
+      setSpans(Automerge.spans(payload.doc, ["text"]))
+    }
+    handle.on("change", listener)
+
+    return () => {
+      handle.off("change", listener)
+    }
+  }, [ debug, handle] )
+
   const [editorState, setEditorState] = useState<EditorState | undefined>(undefined);
   function handleEditorStateChange(state: EditorState) {
-    setEditorState(state);
+    setEditorState(state)
   }
 
   return (

--- a/playground/src/Playground.tsx
+++ b/playground/src/Playground.tsx
@@ -13,6 +13,7 @@ import {
 import { Mark, Node } from "prosemirror-model"
 import { BlockMarker } from "../../src/types"
 import * as Automerge from "@automerge/automerge"
+import { EditorState } from "prosemirror-state"
 
 // @ts-expect-error this is for debug
 window.A = Automerge
@@ -66,6 +67,7 @@ function Playground({ demoMode }: Props) {
       leftHandle={leftHandle}
       rightHandle={rightHandle}
       showTitle={!demoMode}
+      showDebug={!demoMode}
     />
   )
 
@@ -85,6 +87,7 @@ function Playground({ demoMode }: Props) {
             leftHandle={leftHandle}
             rightHandle={rightHandle}
             showTitle={true}
+            showDebug={true}
           />
         ),
       },
@@ -112,27 +115,30 @@ type TabProps = {
   leftHandle: DocHandle<{ text: string }>
   rightHandle: DocHandle<{ text: string }>
   showTitle: boolean
+  showDebug: boolean
 }
 
-function SameSchema({ leftHandle, rightHandle, showTitle }: TabProps) {
+function SameSchema({ leftHandle, rightHandle, showTitle, showDebug }: TabProps) {
   return (
     <div>
       {showTitle && <h2>Same Schema</h2>}
       <div id="editors">
         <div className="editor">
-          <Editor
+          <DebugEditor
             name="left"
             handle={leftHandle}
             path={["text"]}
             schemaAdapter={basicSchemaAdapter}
+            debug={showDebug}
           />
         </div>
         <div className="editor">
-          <Editor
+          <DebugEditor
             name="right"
             handle={rightHandle}
             path={["text"]}
             schemaAdapter={basicSchemaAdapter}
+            debug={showDebug}
           />
         </div>
       </div>
@@ -140,30 +146,84 @@ function SameSchema({ leftHandle, rightHandle, showTitle }: TabProps) {
   )
 }
 
-function DifferentSchema({ leftHandle, rightHandle, showTitle }: TabProps) {
+function DifferentSchema({ leftHandle, rightHandle, showTitle, showDebug }: TabProps) {
   return (
     <div>
       {showTitle && <h2>Different Schema</h2>}
       <div id="editors">
         <div className="editor">
-          <Editor
+          <DebugEditor
             name="left"
             handle={leftHandle}
             path={["text"]}
             schemaAdapter={paragraphAndHeadingSchemaAdapter}
+            debug={showDebug}
           />
         </div>
         <div className="editor">
-          <Editor
+          <DebugEditor
             name="right"
             handle={rightHandle}
             path={["text"]}
             schemaAdapter={paragraphAndListItemsSchemaAdapter}
+            debug={showDebug}
           />
         </div>
       </div>
     </div>
   )
+}
+
+function DebugEditor({
+  name,
+  handle,
+  path,
+  schemaAdapter,
+  debug,
+}: {
+  name?: string
+  handle: DocHandle<unknown>
+  path: Automerge.Prop[]
+  schemaAdapter: SchemaAdapter
+  debug?: boolean
+}) {
+  const [spans, setSpans] = useState(Automerge.spans(handle.doc(), path))
+  handle.on("change", (payload) => {
+    setSpans(Automerge.spans(payload.doc, ["text"]))
+  })
+  const [editorState, setEditorState] = useState<EditorState | undefined>(undefined);
+  function handleEditorStateChange(state: EditorState) {
+    setEditorState(state);
+  }
+
+  return (
+    <div>
+      <Editor
+        name={name}
+        handle={handle}
+        path={path}
+        schemaAdapter={schemaAdapter}
+        onStateChange={handleEditorStateChange}
+      />
+      {debug && (
+        <div style={{display: 'flex'}}>
+          <div>
+            <span>ProseMirror state</span>
+            <pre>
+              {JSON.stringify(editorState?.toJSON(), null, 2)}
+            </pre>
+          </div>
+          <div>
+            <span>Automerge state</span>
+            <pre>
+              {JSON.stringify(spans, null, 2)}
+            </pre>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+
 }
 
 const paragraphAndHeadingSchemaAdapter = new SchemaAdapter({

--- a/playground/src/Playground.tsx
+++ b/playground/src/Playground.tsx
@@ -1,6 +1,10 @@
 import React, { useEffect, useState } from "react"
 import { Editor } from "./Editor"
-import { Repo, DocHandle, DocHandleChangePayload } from "@automerge/automerge-repo"
+import {
+  Repo,
+  DocHandle,
+  DocHandleChangePayload,
+} from "@automerge/automerge-repo"
 //import { MessageChannelNetworkAdapter } from "@automerge/automerge-repo-network-messagechannel"
 import { PausableNetworkAdapter } from "./PausableNetworkAdapter"
 import TabContainer from "./Tabs"
@@ -118,7 +122,12 @@ type TabProps = {
   showDebug: boolean
 }
 
-function SameSchema({ leftHandle, rightHandle, showTitle, showDebug }: TabProps) {
+function SameSchema({
+  leftHandle,
+  rightHandle,
+  showTitle,
+  showDebug,
+}: TabProps) {
   return (
     <div>
       {showTitle && <h2>Same Schema</h2>}
@@ -146,7 +155,12 @@ function SameSchema({ leftHandle, rightHandle, showTitle, showDebug }: TabProps)
   )
 }
 
-function DifferentSchema({ leftHandle, rightHandle, showTitle, showDebug }: TabProps) {
+function DifferentSchema({
+  leftHandle,
+  rightHandle,
+  showTitle,
+  showDebug,
+}: TabProps) {
   return (
     <div>
       {showTitle && <h2>Different Schema</h2>}
@@ -190,7 +204,7 @@ function DebugEditor({
   const [spans, setSpans] = useState(Automerge.spans(handle.doc(), path))
   useEffect(() => {
     if (!debug) {
-      return;
+      return
     }
     function listener(payload: DocHandleChangePayload<unknown>) {
       setSpans(Automerge.spans(payload.doc, ["text"]))
@@ -200,9 +214,11 @@ function DebugEditor({
     return () => {
       handle.off("change", listener)
     }
-  }, [ debug, handle] )
+  }, [debug, handle])
 
-  const [editorState, setEditorState] = useState<EditorState | undefined>(undefined);
+  const [editorState, setEditorState] = useState<EditorState | undefined>(
+    undefined,
+  )
   function handleEditorStateChange(state: EditorState) {
     setEditorState(state)
   }
@@ -217,24 +233,19 @@ function DebugEditor({
         onStateChange={handleEditorStateChange}
       />
       {debug && (
-        <div style={{display: 'flex'}}>
+        <div style={{ display: "flex" }}>
           <div>
             <span>ProseMirror state</span>
-            <pre>
-              {JSON.stringify(editorState?.toJSON(), null, 2)}
-            </pre>
+            <pre>{JSON.stringify(editorState?.toJSON(), null, 2)}</pre>
           </div>
           <div>
             <span>Automerge state</span>
-            <pre>
-              {JSON.stringify(spans, null, 2)}
-            </pre>
+            <pre>{JSON.stringify(spans, null, 2)}</pre>
           </div>
         </div>
       )}
     </div>
   )
-
 }
 
 const paragraphAndHeadingSchemaAdapter = new SchemaAdapter({


### PR DESCRIPTION
While trying to debug some issues, I kept getting lost in the
different states involved here, so I added a debug view to the
Playground, showing each side's ProseMirror EditorState and the Spans
from each Automerge repo side.

<img width="2276" height="3308" alt="image" src="https://github.com/user-attachments/assets/afb27321-94a5-43b6-b010-0a9684a852cb" />

This definitely needs some better presentation, but it might be more
generally useful for debugging. Thoughts? Anything else that would
be useful for a view like this?
