### PR TITLE
inline sources

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,9 @@
   ],
   "extends": "./tsconfig/tsconfig.base.json",
   "compilerOptions": {
-    "types": ["node", "cypress"],
-    "inlineSources": true
+    "types": [
+      "node",
+      "cypress"
+    ]
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
   ],
   "extends": "./tsconfig/tsconfig.base.json",
   "compilerOptions": {
-    "types": ["node", "cypress"]
+    "types": ["node", "cypress"],
+    "inlineSources": true
   }
 }

--- a/tsconfig/tsconfig.build.json
+++ b/tsconfig/tsconfig.build.json
@@ -1,7 +1,10 @@
 {
-  "include": ["../src/**/*.ts"],
+  "include": [
+    "../src/**/*.ts"
+  ],
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": "../src"
+    "rootDir": "../src",
+    "inlineSources": true
   }
 }


### PR DESCRIPTION
Right now source maps are pointing to the src/ folder which is not served with the library making it undebuggable in devtools. This change will inline the source file content in the source maps.