### PR TITLE
include attrParsers for block mappings when using `within`

### DIFF
--- a/src/schema.ts
+++ b/src/schema.ts
@@ -134,11 +134,17 @@ export class SchemaAdapter {
               throw new Error(`${nodeSpec.name} references an unknown outer node
   ${outerName} in its within block mapping`)
             }
-            nodeMappings.push({
+            const nodeMapping: NodeMapping = {
               blockName,
               outer: schema.nodes[outerName],
               content: schema.nodes[nodeName],
-            })
+            }
+        
+            if (adaptSpec.attrParsers != null) {
+              nodeMapping.attrParsers = adaptSpec.attrParsers
+            }
+        
+            nodeMappings.push(nodeMapping)
           }
         }
       }


### PR DESCRIPTION
fix for: https://github.com/automerge/automerge-prosemirror/issues/59